### PR TITLE
Add unsolicited HVX enable/disable command and handler

### DIFF
--- a/test_suite/common/ble_device.py
+++ b/test_suite/common/ble_device.py
@@ -298,7 +298,7 @@ class BleDevice(Device):
             "signedWriteWithoutResponse", "write", "writeLong", "reliableWrite",
             "readCharacteristicDescriptor", "readLongCharacteristicDescriptor",
             "writeCharacteristicDescriptor", "writeLongCharacteristicDescriptor",
-            "negotiateAttMtu"
+            "negotiateAttMtu", "enableUnsolicitedHVX"
         ],
         "gattServer": [
             "instantiateHRM", "updateHRMSensorValue", "declareService",


### PR DESCRIPTION
This adds the ability to receive unsolicited (ie: asynchronous) BLE events whenever the connected device receives an HVX event. This is useful for data logging whereas the `listenHVX` command is blocking and has a finite timeout.