### PR TITLE
Serial configuration

### DIFF
--- a/test_suite/common/ble_device.py
+++ b/test_suite/common/ble_device.py
@@ -15,6 +15,7 @@
 
 import json
 import queue
+from time import sleep
 from typing import List, Optional
 
 from .device import Device
@@ -332,9 +333,10 @@ class BleDevice(Device):
         ]
     }
 
-    def __init__(self, device: Device):
+    def __init__(self, device: Device, command_delay=0):
         """Create a new BLEDevice instance."""
         self.device = device
+        self.command_delay = command_delay
         self.events = queue.Queue()
 
     def command(self, cmd: str, expected_retcode: int = 0, async_command: bool = False) -> CommandResult:
@@ -348,6 +350,7 @@ class BleDevice(Device):
         response = None
 
         if async_command:
+            sleep(self.command_delay)
             self.device.send(cmd)
 
             class AsynchronousResponse:
@@ -390,6 +393,7 @@ class BleDevice(Device):
 
     # Add the proxy methods
     def send(self, command, expected_output=None, wait_before_read=None, wait_for_response=30, assert_output=True):
+        sleep(self.command_delay)
         lines = self.device.send(command, expected_output, wait_before_read, wait_for_response, assert_output)
         return self._filter_events(lines)
 

--- a/test_suite/common/fixtures.py
+++ b/test_suite/common/fixtures.py
@@ -47,6 +47,13 @@ def binaries(request):
     return {}
 
 
+@pytest.fixture(scope="session")
+def serial_inter_byte_delay(request):
+    if request.config.getoption('serial_inter_byte_delay'):
+        return float(request.config.getoption('serial_inter_byte_delay'))
+    return None
+
+
 class BoardAllocation:
     def __init__(self, description: Mapping[str, Any]):
         self.description = description
@@ -55,13 +62,14 @@ class BoardAllocation:
 
 
 class BoardAllocator:
-    def __init__(self, platforms_supported: List[str], binaries: Mapping[str, str]):
+    def __init__(self, platforms_supported: List[str], binaries: Mapping[str, str], serial_inter_byte_delay: float):
         mbed_ls = mbed_lstools.create()
         boards = mbed_ls.list_mbeds(filter_function=lambda m: m['platform_name'] in platforms_supported)
         self.board_description = boards
         self.binaries = binaries
         self.allocation = []  # type: List[BoardAllocation]
         self.flasher = None
+        self.serial_inter_byte_delay = serial_inter_byte_delay
         for desc in boards:
             self.allocation.append(BoardAllocation(desc))
 
@@ -78,7 +86,11 @@ class BoardAllocator:
                     alloc.flashed = True
 
                 # Create the serial connection
-                connection = SerialConnection(port=alloc.description["serial_port"], baudrate=115200)
+                connection = SerialConnection(
+                    port=alloc.description["serial_port"],
+                    baudrate=115200,
+                    inter_byte_delay=self.serial_inter_byte_delay
+                )
                 connection.open()
 
                 # Create the serial device
@@ -113,8 +125,8 @@ class BoardAllocator:
 
 
 @pytest.fixture(scope="session")
-def board_allocator(platforms: List[str], binaries: Mapping[str, str]):
-    yield BoardAllocator(platforms, binaries)
+def board_allocator(platforms: List[str], binaries: Mapping[str, str], serial_inter_byte_delay: float):
+    yield BoardAllocator(platforms, binaries, serial_inter_byte_delay)
 
 
 @pytest.fixture(scope="function")

--- a/test_suite/common/serial_connection.py
+++ b/test_suite/common/serial_connection.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 
 import logging
+from time import sleep
 
 from serial import Serial, SerialException
 
@@ -21,8 +22,9 @@ log = logging.getLogger(__name__)
 
 
 class SerialConnection:
-    def __init__(self, port=None, baudrate=9600, timeout=1):
+    def __init__(self, port=None, baudrate=9600, timeout=1, inter_byte_delay=None):
         self.ser = Serial(port, baudrate, timeout=timeout)
+        self.inter_byte_delay = inter_byte_delay
 
     def open(self):
         """
@@ -49,7 +51,12 @@ class SerialConnection:
         :param data: Data to send
         """
         try:
-            self.ser.write(data)
+            if self.inter_byte_delay:
+                for byte in data:
+                    self.ser.write(bytes([byte]))
+                    sleep(self.inter_byte_delay)
+            else:
+                self.ser.write(data)
         except SerialException as se:
             log.error('Serial connection write error: {}'.format(se))
 

--- a/test_suite/conftest.py
+++ b/test_suite/conftest.py
@@ -27,3 +27,4 @@ def pytest_addoption(parser):
     parser.addoption('--platforms', action='store', help='List of platforms that can be used to run the tests. Platforms are separated by a comma')
     parser.addoption('--binaries', action='store', help='Platform and associated binary in the form platform:binary. Multiple values are separated by a comma')
     parser.addoption('--serial_inter_byte_delay', action='store', help='Time in second between two bytes sent on the serial line (accepts floats)')
+    parser.addoption('--serial_baudrate', action='store', help='Baudrate of the serial port used', default='115200')

--- a/test_suite/conftest.py
+++ b/test_suite/conftest.py
@@ -26,3 +26,4 @@ def pytest_addoption(parser):
     """
     parser.addoption('--platforms', action='store', help='List of platforms that can be used to run the tests. Platforms are separated by a comma')
     parser.addoption('--binaries', action='store', help='Platform and associated binary in the form platform:binary. Multiple values are separated by a comma')
+    parser.addoption('--serial_inter_byte_delay', action='store', help='Time in second between two bytes sent on the serial line (accepts floats)')

--- a/test_suite/conftest.py
+++ b/test_suite/conftest.py
@@ -28,3 +28,4 @@ def pytest_addoption(parser):
     parser.addoption('--binaries', action='store', help='Platform and associated binary in the form platform:binary. Multiple values are separated by a comma')
     parser.addoption('--serial_inter_byte_delay', action='store', help='Time in second between two bytes sent on the serial line (accepts floats)')
     parser.addoption('--serial_baudrate', action='store', help='Baudrate of the serial port used', default='115200')
+    parser.addoption('--command_delay', action='store', help='Delay in seconds before sending a command', default='0')


### PR DESCRIPTION
This PR adds several options to deal with serial issues: 
- `--serial_baudrate`: Specify the baudrate used by the test suite
- `--command_delay`: Force a delay before sending a command
- `--serial_inter_byte_delay`: Add a delay between two bytes sent to connected devices.