### PR TITLE
Add Mbed trace support

### DIFF
--- a/ble-cliapp/mbed_app.json
+++ b/ble-cliapp/mbed_app.json
@@ -25,7 +25,8 @@
             "target.printf_lib": "std",
             "platform.stdio-flush-at-exit": false,
             "platform.stdio-baud-rate": 115200,
-            "cordio.desired-att-mtu": 80
+            "cordio.desired-att-mtu": 80,
+            "mbed-trace.enable": null
         },
         "K64F": {
             "target.features_add": ["BLE"],

--- a/ble-cliapp/source/main.cpp
+++ b/ble-cliapp/source/main.cpp
@@ -186,6 +186,23 @@ void app_start(int, char*[])
     get_serial().baud(115200);    // This is default baudrate for our test applications. 230400 is also working, but not 460800. At least with k64f.
     get_serial().attach(whenRxInterrupt);
 
+    mbed_trace_init();
+    mbed_trace_prefix_function_set([](size_t) {
+        // This is the prefix added before any trace, the new line is used to
+        // ensure the trace is not rendered inside a line containing a json
+        // payload. The test tool filter out traces based on this pattern.
+        static char prefix[] = "\n~~~";
+        return prefix;
+    });
+    mbed_trace_print_function_set([](const char* str) {
+        get_serial().write(str, strlen(str));
+        // Note: line return in mbed_trace somehow doesn't work if color support
+        // is deactivated.
+        get_serial().write("\n", 1);
+    });
+    // Disable color support and carriage return support
+    mbed_trace_config_set(TRACE_ACTIVE_LEVEL_ALL);
+
     cmd_init( &custom_cmd_response_out );
     cmd_set_ready_cb( cmd_ready_cb );
     cmd_history_size(1);

--- a/test_suite/common/serial_device.py
+++ b/test_suite/common/serial_device.py
@@ -95,8 +95,9 @@ class SerialDevice(Device):
                     log.warning('{}: Invalid bytes read: {}'.format(self.name, line))
                     continue
                 plain_line.rstrip()
-                log.info('<--|{}| {}'.format(self.name, plain_line.strip()))
-                self.iq.put(plain_line)
+                if plain_line.strip():
+                    log.info('<--|{}| {}'.format(self.name, plain_line.strip()))
+                    self.iq.put(plain_line)
             else:
                 pass
 


### PR DESCRIPTION
This PR adds support for mbed trace in ble-cliapp and the appropriate filters in the test runtime.  
Please review, we can merge when the trace branch on Mbed OS has been merged. 