### PR TITLE
Add missing parameter set in stop scan test

### DIFF
--- a/test_suite/gap/test_start_stop_scan.py
+++ b/test_suite/gap/test_start_stop_scan.py
@@ -111,6 +111,7 @@ def test_scan_start_stop_can_be_called_in_succession(scanner: BleDevice):
     """startScan should not report scan results when there is no device advertising"""
     # start scan
 
+    scanner.gap.setScanParameters()
     scanner.gap.startScan(0, 'DISABLE', 0)
     assert scanner.gap.isRadioActive().result is True
 


### PR DESCRIPTION
You have to set params before scan, otherwise the state gets stuck in pending. This fixes the test but there is still a need to fix mbed-os.