### PR TITLE
Set tags as first parameter of launch_job

### DIFF
--- a/.github/workflows/ble_tests.yml
+++ b/.github/workflows/ble_tests.yml
@@ -30,7 +30,7 @@ jobs:
           lavacli identities add --uri "$LAVA_SERVER_URL" --username lava-admin --token "$LAVA_SERVER_TOKEN" default
           lavacli workers list
           cd mbed-os-lava-scripts/jobs
-          LAVA_JOB_NO=`./launch_job.sh ble_test.yaml [${{ matrix.MBED_TARGET }}] $REPOSITORY $SHA`
+          LAVA_JOB_NO=`./launch_job.sh [${{ matrix.MBED_TARGET }}] ble_test.yaml $REPOSITORY $SHA`
           echo "Running lava job $LAVA_JOB_NO"
           cd ../..
 


### PR DESCRIPTION
The tags are properly parsed only if they are parsed as the first parameter otherwise they are discarded and all parameters are wrong by one off.